### PR TITLE
Add AI agent instructions for committing compiled tailwind.css

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,32 @@
+# Copilot Instructions
+
+## Project Overview
+
+Zola Devin is a blog theme for the [Zola](https://www.getzola.org/) static site generator, built with Tailwind CSS and vanilla JavaScript.
+
+## Critical: Compiled Tailwind CSS Must Be Committed
+
+`static/tailwind.css` is the compiled Tailwind output and **must be checked into the repository**. This is a Zola theme — end users install it as a git submodule and run `zola build` without Node.js. The compiled CSS must ship with the theme.
+
+Any PR that adds or changes Tailwind utility classes in templates or `static/input.css` must include a rebuilt `tailwind.css`:
+
+```bash
+npx tailwindcss -i ./static/input.css -o ./static/tailwind.css
+```
+
+## Build Commands
+
+```bash
+npm install
+npx tailwindcss -i ./static/input.css -o ./static/tailwind.css
+zola build
+```
+
+## Key Conventions
+
+- Templates use Tera and extend `base.html`
+- Dark mode uses `dark:` variant classes (class-based, not media query)
+- Styles use Tailwind utility classes; custom components are in `static/input.css`
+- Posts use colocated directories: `content/post/{date}-{slug}/index.md`
+- Comments are YAML files colocated with posts
+- Vanilla JS only — no frameworks beyond elasticlunr

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ There are no tests or linting commands configured.
 
 ## Key Conventions
 
+- **`static/tailwind.css` must be committed.** This is a Zola theme — end users install it as a git submodule and run `zola build` without Node.js. The compiled Tailwind CSS must be checked in so it ships with the theme. Any PR that adds or changes Tailwind utility classes in templates or `input.css` must include a rebuilt `tailwind.css` (`npx tailwindcss -i ./static/input.css -o ./static/tailwind.css`).
 - Post front matter uses TOML with `[extra]` and `[taxonomies]` sections
 - Comments are stored as YAML files colocated with the post, not in a database
 - Dark mode is the default; toggled via class on `<html>` element


### PR DESCRIPTION
## Summary
- Updates `CLAUDE.md` with a key convention that `static/tailwind.css` must be committed with any PR that changes Tailwind classes
- Adds `.github/copilot-instructions.md` so GitHub Copilot agents get the same guidance

As a Zola theme, end users install via git submodule and run `zola build` without Node.js. The compiled Tailwind CSS must ship with the theme, so AI agents need to know to rebuild and include it when modifying templates or `input.css`.

## Test plan
- [x] No code changes — documentation only
- [ ] Verify Copilot agent PRs include rebuilt `tailwind.css` going forward

🤖 Generated with [Claude Code](https://claude.ai/code)