### PR TITLE
Build: Rebuild tailwind.css for scoped transitions (PR #26)

### DIFF
--- a/static/tailwind.css
+++ b/static/tailwind.css
@@ -554,7 +554,15 @@ video {
   display: none;
 }
 
-* {
+/* Apply color transitions only to elements that change color during theme switching */
+
+body, header, footer, nav, main, section, article, div, span,
+  h1, h2, h3, h4, h5, h6,
+  p, a, pre, code, blockquote, hr, sup, del, time,
+  th, td, tbody tr,
+  ul, ol,
+  button, input,
+  .btn-primary, .btn-secondary, .nav-link, .card, .footnote {
   transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 200ms;


### PR DESCRIPTION
## Summary
- Commits the compiled `static/tailwind.css` that should have been included in PR #26

PR #26 ("Perf: Scope CSS transitions to theme-sensitive elements only") updated `static/input.css` to replace the universal `*` selector with targeted element selectors for theme transitions, but did not include the rebuilt `tailwind.css`. Without this, theme users pulling the submodule still get the old universal `*` transition rule.

## Test plan
- [x] `tailwind.css` was rebuilt via `npx tailwindcss -i ./static/input.css -o ./static/tailwind.css`
- [x] Diff matches the scoped selector change from PR #26

🤖 Generated with [Claude Code](https://claude.ai/code)