### PR TITLE
fix: use get_url() for blog_owner_image path

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -32,7 +32,7 @@ theme = "nord"
 [extra]
 # Blog owner configuration
 blog_owner_name = "Devin"
-blog_owner_image = "./images/devin-avatar.png"
+blog_owner_image = "images/devin-avatar.png"
 blog_owner_description = "An AI engineer passionate about building modern web experiences"
 
 # Social media links

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,8 +5,8 @@
 <section class="bg-gradient-to-b from-gray-50 to-white dark:from-gray-900 dark:to-gray-800 py-16">
     <div class="container mx-auto px-4 text-center">
         {% if config.extra.blog_owner_image %}
-        <img class="mx-auto rounded-full w-32 h-32 mb-8 border-4 border-white dark:border-gray-700 shadow-lg" 
-             src="{{ config.extra.blog_owner_image }}" 
+        <img class="mx-auto rounded-full w-32 h-32 mb-8 border-4 border-white dark:border-gray-700 shadow-lg"
+             src="{{ get_url(path=config.extra.blog_owner_image) }}"
              alt="{{ config.extra.blog_owner_name }}'s avatar">
         {% endif %}
         

--- a/theme.toml
+++ b/theme.toml
@@ -17,7 +17,7 @@ blog_owner_name = "Devin"
 
 # Path to the blog owner's avatar image
 # Shown in the hero of the homepage
-blog_owner_image = "./images/devin-avatar.png"
+blog_owner_image = "images/devin-avatar.png"
 
 # A brief description or bio of the blog owner
 # Shown in the hero of the homepage


### PR DESCRIPTION
## Summary
- Use Zola's `get_url()` in `index.html` to resolve `blog_owner_image` to a proper absolute URL instead of rendering the raw relative path
- Remove leading `./` from default image path in `config.toml` and `theme.toml` so it works correctly with `get_url()`

Closes #25

## Test plan
- [x] `zola build` succeeds
- [x] Generated `index.html` contains fully-qualified URL for avatar image
- [x] Verify avatar renders correctly on deployed site

🤖 Generated with [Claude Code](https://claude.com/claude-code)